### PR TITLE
fix(spell-check-daily): remove local-cspell-json

### DIFF
--- a/sources/.github/workflows/spell-check-daily.yaml
+++ b/sources/.github/workflows/spell-check-daily.yaml
@@ -19,7 +19,6 @@ jobs:
       - name: Run spell-check
         uses: autowarefoundation/autoware-github-actions/spell-check@v1
         with:
-          local-cspell-json: .cspell.json
           incremental-files-only: false
           cspell-json-url: https://raw.githubusercontent.com/tier4/autoware-spell-check-dict/main/.cspell.json
           dict-packages: |


### PR DESCRIPTION
## Description

This is only used in universe and by an override. Shouldn't be there by default.

Related:
- https://github.com/autowarefoundation/autoware.universe/pull/9527

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
