### PR TITLE
refactor: use run: instead of tag: for action labels

### DIFF
--- a/sources/.github/workflows/build-and-test-differential.yaml
+++ b/sources/.github/workflows/build-and-test-differential.yaml
@@ -16,7 +16,7 @@ jobs:
   make-sure-label-is-present:
     uses: autowarefoundation/autoware-github-actions/.github/workflows/make-sure-label-is-present.yaml@v1
     with:
-      label: tag:run-build-and-test-differential
+      label: run:build-and-test-differential
 
   build-and-test-differential:
     needs: make-sure-label-is-present

--- a/sources/.github/workflows/deploy-docs.yaml
+++ b/sources/.github/workflows/deploy-docs.yaml
@@ -26,7 +26,7 @@ jobs:
   prevent-no-label-execution:
     uses: autowarefoundation/autoware-github-actions/.github/workflows/prevent-no-label-execution.yaml@v1
     with:
-      label: tag:deploy-docs
+      label: run:deploy-docs
 
   deploy-docs:
     needs: prevent-no-label-execution


### PR DESCRIPTION
## Description

![image](https://github.com/user-attachments/assets/61c86d0f-9848-4355-b25f-843d7c7b7c68)

This PR separates the labels that induce an action to `run:` prefix instead of `tag:` to improve the usability.

## How was this PR tested?

As sync-files workflow updates the target repositoies, the labels should be renamed.

## Notes for reviewers

None.

## Effects on system behavior

None.
