### PR TITLE
feat(pre-commit): set name for update commit and make quarterly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,12 @@
 # https://github.com/autowarefoundation/sync-file-templates
 # To make changes, update the source repository and follow the guidelines in its README.
 
+# https://pre-commit.ci/#configuration
 ci:
   autofix_commit_msg: "style(pre-commit): autofix"
+  # we already have our own daily update mechanism, we set this to quarterly
+  autoupdate_schedule: quarterly
+  autoupdate_commit_msg: "ci(pre-commit): quarterly autoupdate"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/sources/.pre-commit-config.yaml
+++ b/sources/.pre-commit-config.yaml
@@ -2,8 +2,12 @@
 # https://github.com/autowarefoundation/sync-file-templates
 # To make changes, update the source repository and follow the guidelines in its README.
 
+# https://pre-commit.ci/#configuration
 ci:
   autofix_commit_msg: "style(pre-commit): autofix"
+  # we already have our own daily update mechanism, we set this to quarterly
+  autoupdate_schedule: quarterly
+  autoupdate_commit_msg: "ci(pre-commit): quarterly autoupdate"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
## Description

Right now pre-commit bot automatically creates update PRs weekly.

**Example PR:**
- https://github.com/autowarefoundation/autoware.core/pull/86

But we already have [a CI workflow](https://github.com/autowarefoundation/sync-file-templates/blob/e2ad32133aa46a29e57662fe49f7bd320624ed5b/sources/.github/workflows/pre-commit-autoupdate.yaml) that checks and updates it daily.

In the best scenario, we would like to disable it but the owner of the bot doesn't permit it. See the following issue for that:
- https://github.com/pre-commit-ci/issues/issues/83#issue-981198237

So I set it to quarterly and also gave it a PR title that wouldn't fail the semantic-pull-request check.

## How was this PR tested?

Wasn't tested but should be fine, it's simple and from here:
- https://pre-commit.ci/#configuration-autoupdate_commit_msg

## Notes for reviewers

None.

## Effects on system behavior

None.
