### PR TITLE
fix: reduce auto-update frequencies

### DIFF
--- a/sources/.github/dependabot.yaml
+++ b/sources/.github/dependabot.yaml
@@ -6,8 +6,9 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval
     schedule:
-      interval: daily
+      interval: monthly
     open-pull-requests-limit: 1
     labels:
       - tag:bot

--- a/sources/.github/workflows/pre-commit-autoupdate.yaml
+++ b/sources/.github/workflows/pre-commit-autoupdate.yaml
@@ -6,7 +6,7 @@ name: pre-commit-autoupdate
 
 on:
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 1 1,4,7,10 * # quarterly
   workflow_dispatch:
 
 jobs:

--- a/sources/.github/workflows/pre-commit-optional-autoupdate.yaml
+++ b/sources/.github/workflows/pre-commit-optional-autoupdate.yaml
@@ -6,7 +6,7 @@ name: pre-commit-optional-autoupdate
 
 on:
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 1 1,4,7,10 * # quarterly
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

This will reduce the self-update frequencies of:
- dependabot to once a month
- pre-commit to once every 3 months.

This should reduce the update PRs we are supposed to maintain. Since we have too many repos to maintain these across and we utilize sync-files, it adds a lot of burden to keep everything up-to-date daily.

These new low frequencies should suffice.

## How was this PR tested?

It's a simple change.
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval

### Breakdown of `cron: 0 0 1 1,4,7,10 *`:
- **`0 0`**: At midnight (00:00 hours)
- **`1`**: On the 1st day of the month
- **`1,4,7,10`**: In January, April, July, and October (quarterly)
- **`*`**: Every day of the week (no restriction based on the day of the week)

## Notes for reviewers

None.

## Effects on system behavior

None.
