### PR TITLE
revert: "feat(pre-commit-optional): update version (#22)"

### DIFF
--- a/sources/.pre-commit-config-optional.yaml
+++ b/sources/.pre-commit-config-optional.yaml
@@ -4,7 +4,7 @@
 
 repos:
   - repo: https://github.com/tcort/markdown-link-check
-    rev: v3.13.6
+    rev: v3.12.2
     hooks:
       - id: markdown-link-check
         args: [--quiet, --config=.markdown-link-check.json]


### PR DESCRIPTION
This reverts commit 2b0c922a1826f045248702f79f335e59937ebdb8.

## Description

**Reason:** markdown-link-check stopped working and it's a widely known bug with the latest version.

- https://github.com/tcort/markdown-link-check/issues/369

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
