### PR TITLE
feat(github-release.yaml): version release support using ROS release tools

### DIFF
--- a/sources/.github/workflows/github-release.yaml
+++ b/sources/.github/workflows/github-release.yaml
@@ -6,14 +6,12 @@ name: github-release
 
 on:
   push:
-    branches:
-      - beta/v*
     tags:
-      - v*
+      - "[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
     inputs:
-      beta-branch-or-tag-name:
-        description: The name of the beta branch or tag to release
+      tag-name:
+        description: The name of the tag to release
         type: string
         required: true
 
@@ -25,36 +23,24 @@ jobs:
         id: set-tag-name
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            REF_NAME="${{ github.event.inputs.beta-branch-or-tag-name }}"
+            REF_NAME="${{ github.event.inputs.tag-name }}"
           else
             REF_NAME="${{ github.ref_name }}"
           fi
 
-          echo "ref-name=$REF_NAME" >> $GITHUB_OUTPUT
-          echo "tag-name=${REF_NAME#beta/}" >> $GITHUB_OUTPUT
+          echo "tag-name=$REF_NAME" >> $GITHUB_OUTPUT
 
       - name: Check out repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ steps.set-tag-name.outputs.ref-name }}
-
-      - name: Set target name for beta branches
-        id: set-target-name
-        run: |
-          if [[ "${{ steps.set-tag-name.outputs.ref-name }}" =~ "beta/" ]]; then
-            echo "target-name=${{ steps.set-tag-name.outputs.ref-name }}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Create a local tag for beta branches
-        run: |
-          if [ "${{ steps.set-target-name.outputs.target-name }}" != "" ]; then
-            git tag "${{ steps.set-tag-name.outputs.tag-name }}"
-          fi
+          ref: ${{ steps.set-tag-name.outputs.tag-name }}
 
       - name: Run generate-changelog
         id: generate-changelog
         uses: autowarefoundation/autoware-github-actions/generate-changelog@v1
+        with:
+          git-cliff-args: --tag-pattern "^(\d+)\.(\d+)\.(\d+)$" --latest
 
       - name: Select verb
         id: select-verb
@@ -74,7 +60,7 @@ jobs:
         run: |
           gh release ${{ steps.select-verb.outputs.verb }} "${{ steps.set-tag-name.outputs.tag-name }}" \
             --draft \
-            --target "${{ steps.set-target-name.outputs.target-name }}" \
+            --target "main" \
             --title "Release ${{ steps.set-tag-name.outputs.tag-name }}" \
             --notes "$NOTES"
         env:


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware/pull/5652 modifications is applied to `sync-files-templates` instead of `autoware`. The adjustments to ensure that this change does not apply to tier4 fork repositories with special release rules have already been completed.

- https://github.com/tier4/autoware.universe/pull/1776
- https://github.com/tier4/autoware_launch/pull/738

## How was this PR tested?

- https://github.com/youtalk/autoware/actions/runs/12821081649
- https://github.com/youtalk/autoware/releases/tag/untagged-abca71c3a111e29fae42

## Notes for reviewers

None.

## Effects on system behavior

None.
