### PR TITLE
fix(github-release.yaml): remove `target` option

### DIFF
--- a/sources/.github/workflows/github-release.yaml
+++ b/sources/.github/workflows/github-release.yaml
@@ -60,7 +60,6 @@ jobs:
         run: |
           gh release ${{ steps.select-verb.outputs.verb }} "${{ steps.set-tag-name.outputs.tag-name }}" \
             --draft \
-            --target "main" \
             --title "Release ${{ steps.set-tag-name.outputs.tag-name }}" \
             --notes "$NOTES"
         env:


### PR DESCRIPTION
## Description

The `autoware` repository has tags in the `main` branch, but other branches have tags in the either `main` or `humble` branches. In other words, specifying the `main` branch may result in cases where the `github-release` workflow does not work. The target option is not mandatory, and if not specified, the branch with tags will be automatically selected, so this PR removes the option.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
