### PR TITLE
feat(build-and-test*.yaml): add `jazzy` job

### DIFF
--- a/sources/.github/workflows/build-and-test-differential.yaml
+++ b/sources/.github/workflows/build-and-test-differential.yaml
@@ -28,9 +28,13 @@ jobs:
       matrix:
         rosdistro:
           - humble
+          - jazzy
         include:
           - rosdistro: humble
             container: ros:humble
+            build-depends-repos: build_depends.repos
+          - rosdistro: jazzy
+            container: ros:jazzy
             build-depends-repos: build_depends.repos
     steps:
       - name: Set PR fetch depth

--- a/sources/.github/workflows/build-and-test.yaml
+++ b/sources/.github/workflows/build-and-test.yaml
@@ -20,9 +20,13 @@ jobs:
       matrix:
         rosdistro:
           - humble
+          - jazzy
         include:
           - rosdistro: humble
             container: ros:humble
+            build-depends-repos: build_depends.repos
+          - rosdistro: jazzy
+            container: ros:jazzy
             build-depends-repos: build_depends.repos
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Description

We will also add jobs to build and test with ROS 2 Jazzy, as we move forward with supporting not only ROS 2 Humble but also Jazzy for Autoware and related repositories.

Note that `autoware_core` and `autoware_universe` are not affected since these templates are not synced with them.

- https://github.com/autowarefoundation/autoware_core/blob/main/.github/sync-files.yaml
- https://github.com/autowarefoundation/autoware_universe/blob/main/.github/sync-files.yaml

## How was this PR tested?

- https://github.com/autowarefoundation/autoware_lanelet2_extension/pull/59
- https://github.com/autowarefoundation/autoware_lanelet2_extension/actions/runs/14299837838/job/40072290538?pr=59
- https://github.com/autowarefoundation/autoware_lanelet2_extension/actions/runs/14299837838/job/40072290543?pr=59

## Notes for reviewers

None.

## Effects on system behavior

None.
