### PR TITLE
feat(pre-commit): add autoware-guideline-check

### DIFF
--- a/sources/.pre-commit-config.yaml
+++ b/sources/.pre-commit-config.yaml
@@ -41,6 +41,11 @@ repos:
     hooks:
       - id: yamllint
 
+  - repo: https://github.com/autowarefoundation/autoware-guideline-check
+    rev: 0.1.0
+    hooks:
+      - id: check-package-depends
+
   - repo: https://github.com/tier4/pre-commit-hooks-ros
     rev: v0.10.0
     hooks:


### PR DESCRIPTION
## Description

Add autoware-guideline-check pre-commit. This pre-commit automatically adds exec_depend like [this PR](https://github.com/autowarefoundation/autoware_universe/pull/10404).
See https://github.com/autowarefoundation/autoware-guideline-check for details.

## How was this PR tested?

https://github.com/autowarefoundation/autoware_universe/pull/10404

## Notes for reviewers

None.

## Effects on system behavior

None.
