### PR TITLE
feat: disable MD059 - Link text should be descriptive

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -7,5 +7,7 @@ MD029:
   style: ordered
 MD033: false
 MD041: false
+MD045: false
 MD046: false
 MD049: false
+MD059: false

--- a/sources/.markdownlint.yaml
+++ b/sources/.markdownlint.yaml
@@ -14,3 +14,4 @@ MD041: false
 MD045: false
 MD046: false
 MD049: false
+MD059: false


### PR DESCRIPTION
## Description

- https://github.com/DavidAnson/markdownlint/blob/main/doc/md059.md
- This rule is triggered when a link is set with generic text like "Click here", "here", or "learn more", giving it a generic accessible name.
- This rule was introduced in [2025-02-14](https://github.com/DavidAnson/markdownlint/commits/main/doc/md059.md).

This PR disables this check.

**Affected PR:**
- https://github.com/autowarefoundation/autoware_tools/pull/231#issuecomment-3124016232
- https://results.pre-commit.ci/run/github/740824288/1753589708.dzhySaixScaFikiBQg0WTg
- [link](https://github.com/autowarefoundation/autoware_tools/blob/8612c17b02a73d1d9252082960165a0d7c62769d/control_data_collecting_tool/README.md?plain=1#L56) `Set an initial pose, see [here](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/planning-simulation/#2-set-an-initial-pose-for-the-ego-vehicle).`

**Reasons for disabling:**
- Updating all existing instances of "here" or similar links would require a large-scale rewrite of documentation that is out of scope.  
- Short phrases like "see here" are often clearer and more natural in technical instructions than verbose descriptive link text.  
- The documentation is primarily developer-facing, where context is already clear and accessibility impact is minimal.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
