### PR TITLE
feat: improve search for mkdocs-base.yaml

### DIFF
--- a/sources/mkdocs-base.yaml
+++ b/sources/mkdocs-base.yaml
@@ -62,7 +62,9 @@ plugins:
   - macros
   - mkdocs-video
   - same-dir
-  - search
+  # https://squidfunk.github.io/mkdocs-material/plugins/search/#config.separator
+  - search:
+      separator: '[\s\-_,:!=\[\]()"/]+|(?!\b)(?=[A-Z][a-z])|\.(?!\d)|&[lg]t;'
 
 markdown_extensions:
   - abbr


### PR DESCRIPTION
## Description

> Use this setting to specify the separator used to split words when building the search index on the client side. The default value is automatically computed from the [site language](https://squidfunk.github.io/mkdocs-material/setup/changing-the-language/#site-language), but can also be explicitly set to another value with:

This improves the reach of search. It is already used in autoware.universe. This also adds it to the mkdocs-base.yaml.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
