### PR TITLE
ci: add `backport.yaml`

### DIFF
--- a/sources/.github/workflows/backport.yaml
+++ b/sources/.github/workflows/backport.yaml
@@ -1,0 +1,54 @@
+name: backport
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    runs-on: ubuntu-22.04
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - uses: tibdex/backport@v2
+        id: backport
+        with:
+          github_token: ${{ steps.generate-token.outputs.token }}
+          title_template: "<%= title %> (backport #<%= number %>)"
+
+      - name: Request review from original author
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          PR_JSON: ${{ steps.backport.outputs.created_pull_requests }}
+          ORIGINAL_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          echo "Created PRs JSON: $PR_JSON"
+          echo "Original PR Author: $ORIGINAL_AUTHOR"
+
+          # Use 'jq' to parse the JSON and extract all PR numbers (values)
+          # Loop through the extracted PR numbers, one per line
+          echo "$PR_JSON" | jq -r 'to_entries | .[] | .value' | while read -r pr_num; do
+            if [ -n "$pr_num" ]; then
+              echo "Requesting review for PR #$pr_num from $ORIGINAL_AUTHOR..."
+
+              # Use the 'gh' CLI to add the reviewer
+              gh pr edit "$pr_num" --add-reviewer "$ORIGINAL_AUTHOR" --repo "${{ github.repository }}"
+            fi
+          done

--- a/sources/.github/workflows/backport.yaml
+++ b/sources/.github/workflows/backport.yaml
@@ -1,13 +1,13 @@
+# This file is automatically synced from:
+# https://github.com/autowarefoundation/sync-file-templates
+# To make changes, update the source repository and follow the guidelines in its README.
+
 name: backport
 on:
   pull_request_target:
     types:
       - closed
       - labeled
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   backport:
@@ -43,16 +43,17 @@ jobs:
           PR_JSON: ${{ steps.backport.outputs.created_pull_requests }}
           ORIGINAL_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
+          set -e
           echo "Created PRs JSON: $PR_JSON"
           echo "Original PR Author: $ORIGINAL_AUTHOR"
 
-          # Use 'jq' to parse the JSON and extract all PR numbers (values)
-          # Loop through the extracted PR numbers, one per line
-          echo "$PR_JSON" | jq -r 'to_entries | .[] | .value' | while read -r pr_num; do
+          # Use 'jq' to parse the JSON and extract all PR numbers
+          pr_numbers=($(echo "$PR_JSON" | jq -r 'to_entries | .[] | .value'))
+
+          # Loop through the array of PR numbers
+          for pr_num in "${pr_numbers[@]}"; do
             if [ -n "$pr_num" ]; then
               echo "Requesting review for PR #$pr_num from $ORIGINAL_AUTHOR..."
-
-              # Use the 'gh' CLI to add the reviewer
               gh pr edit "$pr_num" --add-reviewer "$ORIGINAL_AUTHOR" --repo "${{ github.repository }}"
             fi
           done

--- a/sources/.github/workflows/backport.yaml
+++ b/sources/.github/workflows/backport.yaml
@@ -5,6 +5,10 @@ on:
       - closed
       - labeled
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   backport:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Description

Add a sync file template `.github/workflows/backport.yaml`, which is AWF backport with review request step for the original author after backporting, so that the author is reminded to properly review and sync backported PRs into the target branch.

## How was this PR tested?

1. Merged the PR https://github.com/paulsohn/autoware/pull/7 from `paulsohn:foo` -> `paulsohn:test-backport`, with tag `backport test-backport-1` and `backport test-backport-2`; all of them have this updated workflow.
2. My github app (set to provide `APP_ID` and `PRIVATE_KEY`) generated two backport PRs
 https://github.com/paulsohn/autoware/pull/8 (onto `paulsohn:test-backport-1`) and https://github.com/paulsohn/autoware/pull/9 (onto `paulsohn:test-backport-2`)

## Notes for reviewers

The `output.created_pull_requests` of `tibdex/backport` follows the below structure:
```json
{
    "branch1": 1111, // Backport PR no. for branch1
    "branch2": 2222 // Backport PR no. for branch2
}
```

The backport workflow is introduced in https://github.com/autowarefoundation/autoware/pull/2856 , presumably to support TIER IV branch convention. Although AWF Autoware itself does not have such convention, this PR is beneficial to everyone depending on this workflow.

See also: https://github.com/autowarefoundation/autoware/pull/6583 (this has been done first)

## Effects on system behavior

None.
