### PR TITLE
refactor: rename github release title

### DIFF
--- a/sources/.github/workflows/github-release.yaml
+++ b/sources/.github/workflows/github-release.yaml
@@ -60,7 +60,7 @@ jobs:
         run: |
           gh release ${{ steps.select-verb.outputs.verb }} "${{ steps.set-tag-name.outputs.tag-name }}" \
             --draft \
-            --title "Release ${{ steps.set-tag-name.outputs.tag-name }}" \
+            --title "${{ steps.set-tag-name.outputs.tag-name }}" \
             --notes "$NOTES"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Our release notes and default github release notes don't have "Release " prefix in the title.

This makes it consistent with our manually generated release notes.

Check out:
- https://github.com/autowarefoundation/autoware_core/releases
- https://github.com/autowarefoundation/autoware_universe/releases
- https://github.com/autowarefoundation/autoware_msgs/releases

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
