### PR TITLE
feat(mkdocs.yaml): add tasklist and details extensions

### DIFF
--- a/sources/mkdocs.yaml
+++ b/sources/mkdocs.yaml
@@ -85,10 +85,13 @@ markdown_extensions:
       format: svg
   - pymdownx.arithmatex:
       generic: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
   - pymdownx.details
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
+  - pymdownx.details
   - pymdownx.highlight
   - pymdownx.snippets:
       auto_append:


### PR DESCRIPTION
## Description

These extensions are added to autoware_core with:
- https://github.com/autowarefoundation/autoware_core/pull/687/files (pymdownx.tasklist)
- https://github.com/autowarefoundation/autoware_core/pull/656/files#diff-57381c8acc17df6530456c578e76d03d4a1cb287f7edd980502b4a9cedb9524d (pymdownx.details)

This PR adds it to the general definition, as these can be useful for the other repos as well.

They are present in the autoware_core main branch:
https://github.com/autowarefoundation/autoware_core/blob/14135b71f9b7c1630035fd78244eedcc1826600d/mkdocs.yaml#L87-L91

## How was this PR tested?

It's already a part of autoware_core.

Related PR:
- https://github.com/autowarefoundation/autoware_core/pull/592

## Notes for reviewers

None.

## Effects on system behavior

None.
