### PR TITLE
chore(mkdocs): add pymdownx.tasklist to base

### DIFF
--- a/sources/mkdocs-base.yaml
+++ b/sources/mkdocs-base.yaml
@@ -96,6 +96,8 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tasklist:
+      custom_checkbox: true
   - toc:
       permalink: "#"
       toc_depth: 3

--- a/sources/mkdocs.yaml
+++ b/sources/mkdocs.yaml
@@ -85,13 +85,10 @@ markdown_extensions:
       format: svg
   - pymdownx.arithmatex:
       generic: true
-  - pymdownx.tasklist:
-      custom_checkbox: true
   - pymdownx.details
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
-  - pymdownx.details
   - pymdownx.highlight
   - pymdownx.snippets:
       auto_append:
@@ -101,6 +98,8 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tasklist:
+      custom_checkbox: true
   - toc:
       permalink: "#"
       toc_depth: 3


### PR DESCRIPTION
## Description

It turns out that autoware_core uses `mkdocs-base.yaml` instead.

https://github.com/autowarefoundation/autoware_core/blob/14135b71f9b7c1630035fd78244eedcc1826600d/.github/sync-files.yaml#L45-L57

This PR adds the extension to that file.

Also it seems `pymdownx.details` already exists in the list.
https://github.com/autowarefoundation/autoware_core/commit/fd18035ab608bcc514ef2489d7b15a0ddc581b5b#r170963415 this PR duplicated it.

This PR rearranges them.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
