### PR TITLE
feat: use native concurrency, and deprecate cancel-previous-workflows

### DIFF
--- a/sources/.github/workflows/build-and-test-differential.yaml
+++ b/sources/.github/workflows/build-and-test-differential.yaml
@@ -12,6 +12,10 @@ on:
       - reopened
       - labeled
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   make-sure-label-is-present:
     uses: autowarefoundation/autoware-github-actions/.github/workflows/make-sure-label-is-present.yaml@v1

--- a/sources/.github/workflows/build-and-test.yaml
+++ b/sources/.github/workflows/build-and-test.yaml
@@ -10,6 +10,10 @@ on:
     - cron: 0 0 * * *
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     if: ${{ github.event_name != 'push' || github.ref_name == github.event.repository.default_branch }}

--- a/sources/.github/workflows/cancel-previous-workflows.yaml
+++ b/sources/.github/workflows/cancel-previous-workflows.yaml
@@ -2,6 +2,8 @@
 # https://github.com/autowarefoundation/sync-file-templates
 # To make changes, update the source repository and follow the guidelines in its README.
 
+# Deprecated: Use concurrency in each workflow instead.
+
 name: cancel-previous-workflows
 
 on:

--- a/sources/.github/workflows/check-build-depends.yaml
+++ b/sources/.github/workflows/check-build-depends.yaml
@@ -9,6 +9,10 @@ on:
     paths:
       - build_depends*.repos
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-build-depends:
     runs-on: ubuntu-22.04

--- a/sources/.github/workflows/clang-tidy-pr-comments-manually.yaml
+++ b/sources/.github/workflows/clang-tidy-pr-comments-manually.yaml
@@ -10,6 +10,11 @@ on:
       workflow_run_id_or_url:
         description: The target workflow run ID or URL of the build-and-test-differential workflow
         required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   clang-tidy-pr-comments-manually:
     runs-on: ubuntu-22.04

--- a/sources/.github/workflows/clang-tidy-pr-comments.yaml
+++ b/sources/.github/workflows/clang-tidy-pr-comments.yaml
@@ -11,6 +11,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   clang-tidy-pr-comments:
     if: ${{ github.event.workflow_run.event == 'pull_request' && contains(fromJson('["success", "failure"]'), github.event.workflow_run.conclusion) }}

--- a/sources/.github/workflows/comment-on-pr.yaml
+++ b/sources/.github/workflows/comment-on-pr.yaml
@@ -6,6 +6,10 @@ name: comment-on-pr
 on:
   pull_request_target:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   comment-on-pr:
     runs-on: ubuntu-22.04

--- a/sources/.github/workflows/delete-closed-pr-docs.yaml
+++ b/sources/.github/workflows/delete-closed-pr-docs.yaml
@@ -9,6 +9,10 @@ on:
     - cron: 0 0 * * *
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   delete-closed-pr-docs:
     runs-on: ubuntu-22.04

--- a/sources/.github/workflows/deploy-docs.yaml
+++ b/sources/.github/workflows/deploy-docs.yaml
@@ -22,6 +22,10 @@ on:
       - labeled
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   prevent-no-label-execution:
     uses: autowarefoundation/autoware-github-actions/.github/workflows/prevent-no-label-execution.yaml@v1

--- a/sources/.github/workflows/github-release.yaml
+++ b/sources/.github/workflows/github-release.yaml
@@ -15,6 +15,10 @@ on:
         type: string
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   github-release:
     runs-on: ubuntu-22.04

--- a/sources/.github/workflows/pr-agent.yaml
+++ b/sources/.github/workflows/pr-agent.yaml
@@ -9,6 +9,10 @@ on:
     types: [opened, reopened]
   issue_comment:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pr_agent_job:
     runs-on: ubuntu-22.04

--- a/sources/.github/workflows/pre-commit-autoupdate.yaml
+++ b/sources/.github/workflows/pre-commit-autoupdate.yaml
@@ -9,6 +9,10 @@ on:
     - cron: 0 0 1 1,4,7,10 * # quarterly
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-secret:
     uses: autowarefoundation/autoware-github-actions/.github/workflows/check-secret.yaml@v1

--- a/sources/.github/workflows/pre-commit-optional-autoupdate.yaml
+++ b/sources/.github/workflows/pre-commit-optional-autoupdate.yaml
@@ -9,6 +9,10 @@ on:
     - cron: 0 0 1 1,4,7,10 * # quarterly
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-secret:
     uses: autowarefoundation/autoware-github-actions/.github/workflows/check-secret.yaml@v1

--- a/sources/.github/workflows/pre-commit-optional.yaml
+++ b/sources/.github/workflows/pre-commit-optional.yaml
@@ -7,6 +7,10 @@ name: pre-commit-optional
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit-optional:
     runs-on: ubuntu-22.04

--- a/sources/.github/workflows/pre-commit.yaml
+++ b/sources/.github/workflows/pre-commit.yaml
@@ -7,6 +7,10 @@ name: pre-commit
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     if: ${{ github.event.repository.private }} # Use pre-commit.ci for public repositories

--- a/sources/.github/workflows/semantic-pull-request.yaml
+++ b/sources/.github/workflows/semantic-pull-request.yaml
@@ -11,6 +11,10 @@ on:
       - edited
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   semantic-pull-request:
     uses: autowarefoundation/autoware-github-actions/.github/workflows/semantic-pull-request.yaml@v1

--- a/sources/.github/workflows/spell-check-daily.yaml
+++ b/sources/.github/workflows/spell-check-daily.yaml
@@ -9,6 +9,10 @@ on:
     - cron: 0 0 * * *
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   spell-check-daily:
     runs-on: ubuntu-22.04

--- a/sources/.github/workflows/spell-check-differential.yaml
+++ b/sources/.github/workflows/spell-check-differential.yaml
@@ -7,6 +7,10 @@ name: spell-check-differential
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   spell-check-differential:
     runs-on: ubuntu-22.04

--- a/sources/.github/workflows/sync-files.yaml
+++ b/sources/.github/workflows/sync-files.yaml
@@ -9,6 +9,10 @@ on:
     - cron: 0 0 * * *
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-secret:
     uses: autowarefoundation/autoware-github-actions/.github/workflows/check-secret.yaml@v1

--- a/sources/.github/workflows/update-codeowners-from-packages.yaml
+++ b/sources/.github/workflows/update-codeowners-from-packages.yaml
@@ -9,6 +9,10 @@ on:
     - cron: 0 0 * * *
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-secret:
     uses: autowarefoundation/autoware-github-actions/.github/workflows/check-secret.yaml@v1


### PR DESCRIPTION
## Description

Attach [`concurrency`](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency) entry for all template yaml and deprecate `cancel-previous-workflows`.

Now each workflow of each head (e.g. in PR case, branch) will have its own concurrency group, that is, new workflow will cancel the previous workflow.

## How was this PR tested?

Tested the concurrency functionality on my local fork PR https://github.com/paulsohn/autoware/pull/6 , and pushed a commit.

https://github.com/paulsohn/autoware/actions/runs/19915910231 and https://github.com/paulsohn/autoware/actions/runs/19915910224 are canceled on behalf of new workflows in the same concurrency group https://github.com/paulsohn/autoware/actions/runs/19915939774 and  https://github.com/paulsohn/autoware/actions/runs/19915939792 respectively.

## Notes for reviewers

None.

## Effects on system behavior

None.
