### PR TITLE
fix: disable concurrency for pull_request_target triggered workflows

### DIFF
--- a/sources/.github/workflows/comment-on-pr.yaml
+++ b/sources/.github/workflows/comment-on-pr.yaml
@@ -6,10 +6,6 @@ name: comment-on-pr
 on:
   pull_request_target:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   comment-on-pr:
     runs-on: ubuntu-22.04

--- a/sources/.github/workflows/deploy-docs.yaml
+++ b/sources/.github/workflows/deploy-docs.yaml
@@ -22,6 +22,10 @@ on:
       - labeled
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   prevent-no-label-execution:
     uses: autowarefoundation/autoware-github-actions/.github/workflows/prevent-no-label-execution.yaml@v1

--- a/sources/.github/workflows/deploy-docs.yaml
+++ b/sources/.github/workflows/deploy-docs.yaml
@@ -22,10 +22,6 @@ on:
       - labeled
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   prevent-no-label-execution:
     uses: autowarefoundation/autoware-github-actions/.github/workflows/prevent-no-label-execution.yaml@v1

--- a/sources/.github/workflows/semantic-pull-request.yaml
+++ b/sources/.github/workflows/semantic-pull-request.yaml
@@ -11,10 +11,6 @@ on:
       - edited
       - synchronize
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   semantic-pull-request:
     uses: autowarefoundation/autoware-github-actions/.github/workflows/semantic-pull-request.yaml@v1


### PR DESCRIPTION
## Description

A follow-up for #47 . As [Copilot suggests](https://github.com/autowarefoundation/sync-file-templates/pull/40#discussion_r2592505817), it has side effects.

This PR removes concurrency from `comment-on-pr`, `semantic-pull-request`, and `deploy-docs`, which are intended to finish very shortly (except deploy-docs with label attached; maybe tags are better suited than PRs here) so concurrent jobs cause little harm while cancellation of it would be frustrating.

We can alternatively consider triggering by `pull_request`, but considering that many PRs are from forks, it might cause their CIs to fail.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
