### PR TITLE
ci: add `github.event_name` for concurrency key

### DIFF
--- a/sources/.github/workflows/build-and-test-differential.yaml
+++ b/sources/.github/workflows/build-and-test-differential.yaml
@@ -13,7 +13,7 @@ on:
       - labeled
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/sources/.github/workflows/build-and-test.yaml
+++ b/sources/.github/workflows/build-and-test.yaml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/sources/.github/workflows/check-build-depends.yaml
+++ b/sources/.github/workflows/check-build-depends.yaml
@@ -10,7 +10,7 @@ on:
       - build_depends*.repos
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/sources/.github/workflows/clang-tidy-pr-comments-manually.yaml
+++ b/sources/.github/workflows/clang-tidy-pr-comments-manually.yaml
@@ -12,7 +12,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/sources/.github/workflows/clang-tidy-pr-comments.yaml
+++ b/sources/.github/workflows/clang-tidy-pr-comments.yaml
@@ -12,7 +12,7 @@ on:
       - completed
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/sources/.github/workflows/delete-closed-pr-docs.yaml
+++ b/sources/.github/workflows/delete-closed-pr-docs.yaml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/sources/.github/workflows/deploy-docs.yaml
+++ b/sources/.github/workflows/deploy-docs.yaml
@@ -23,7 +23,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/sources/.github/workflows/github-release.yaml
+++ b/sources/.github/workflows/github-release.yaml
@@ -16,7 +16,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/sources/.github/workflows/pr-agent.yaml
+++ b/sources/.github/workflows/pr-agent.yaml
@@ -10,7 +10,7 @@ on:
   issue_comment:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/sources/.github/workflows/pre-commit-autoupdate.yaml
+++ b/sources/.github/workflows/pre-commit-autoupdate.yaml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/sources/.github/workflows/pre-commit-optional-autoupdate.yaml
+++ b/sources/.github/workflows/pre-commit-optional-autoupdate.yaml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/sources/.github/workflows/pre-commit-optional.yaml
+++ b/sources/.github/workflows/pre-commit-optional.yaml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/sources/.github/workflows/pre-commit.yaml
+++ b/sources/.github/workflows/pre-commit.yaml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/sources/.github/workflows/spell-check-daily.yaml
+++ b/sources/.github/workflows/spell-check-daily.yaml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/sources/.github/workflows/spell-check-differential.yaml
+++ b/sources/.github/workflows/spell-check-differential.yaml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/sources/.github/workflows/sync-files.yaml
+++ b/sources/.github/workflows/sync-files.yaml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/sources/.github/workflows/update-codeowners-from-packages.yaml
+++ b/sources/.github/workflows/update-codeowners-from-packages.yaml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Description

I had a suggestion to add `github.event_name` as another key for concurrency group. https://github.com/autowarefoundation/autoware/pull/6622#discussion_r2643423136

Agreeing with that, I update existing concurrency group except for those which will be removed with #49 .

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
