### PR TITLE
chore: bump markdownlint-cli to version v0.46.0 -> v0.47.0

### DIFF
--- a/sources/.pre-commit-config.yaml
+++ b/sources/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
         args: [--markdown-linebreak-ext=md]
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.46.0
+    rev: v0.47.0
     hooks:
       - id: markdownlint
         args: [-c, .markdownlint.yaml, --fix]


### PR DESCRIPTION
## Description

MD060 introduced in markdownlint-cli v0.46.0 (markdownlint v0.39.0) has problems on CJK support, which is fixed in markdownlint-cli v0.47.0 (markdownlint v0.40.0). Since many contributors for Autoware are from CJK (namely, TIER IV is Japan-based), this breaks pre-commit for bunch of README.md s we are using. Let's bump the version early.

* https://github.com/igorshubovych/markdownlint-cli/issues/580
* https://github.com/DavidAnson/markdownlint/issues/1869

## How was this PR tested?

Here is a piece of `README.md` using for some ansible role:

```md
| Variables                           | Default Value                                               | Roles                                          |
| ----------------------------------- | ----------------------------------------------------------- | ---------------------------------------------- |
| setup_loremipsu_service             | true                                                        | loremipsu.serviceの設定の有効化                |
```

`pre-commit run markdownlint --file roles/loremipsu/README.md` fails on v0.46.0, and I bumped the `.pre-commit-config.yaml` as in this PR and the same run passes.

## Notes for reviewers

None.

## Effects on system behavior

None.
