### PR TITLE
feat(build-and-test-differential): use require-label

### DIFF
--- a/sources/.github/workflows/build-and-test-differential.yaml
+++ b/sources/.github/workflows/build-and-test-differential.yaml
@@ -17,14 +17,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  make-sure-label-is-present:
-    uses: autowarefoundation/autoware-github-actions/.github/workflows/make-sure-label-is-present.yaml@v1
+  require-label:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/require-label.yaml@v1
     with:
       label: run:build-and-test-differential
 
   build-and-test-differential:
-    needs: make-sure-label-is-present
-    if: ${{ needs.make-sure-label-is-present.outputs.result == 'true' }}
+    needs: require-label
+    if: ${{ needs.require-label.outputs.result == 'true' }}
     runs-on: ubuntu-22.04
     container: ${{ matrix.container }}
     strategy:


### PR DESCRIPTION
## Description

Similar to https://github.com/autowarefoundation/autoware_universe/blob/1e1b562f2663c3904405073df89ea50dde61f441/.github/workflows/build-test-tidy-pr.yaml#L16-L19 use require label or it can be circumvented by not adding a label.

- `make-sure-label-is-present.yaml` will skip ⏭️ without label.
- `require-label.yaml` will fail ❌ without label.

## How was this PR tested?

- Tested here: https://github.com/autowarefoundation/autoware_launch/pull/1726
