### PR TITLE
ci: add `-no-error-on-unmatched-pattern` flag for prettier

### DIFF
--- a/sources/.pre-commit-config.yaml
+++ b/sources/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
     rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
+        args: [--no-error-on-unmatched-pattern]
 
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.37.1


### PR DESCRIPTION
## Description

If we only update `*.params.yaml`, then prettier fails.
A workaround has been to update `*(non-params).yaml` with dummy comment, create a PR and directly revert it, but we want to go more directly.

## How was this PR tested?

Add this flag and then update some `*.params.yaml`, and pre-commit passes. Without it, pre-commit fails.

## Notes for reviewers

None.

## Effects on system behavior

None.
