### PR TITLE
feat(pre-commit-config): reduce auto update frequency

### DIFF
--- a/sources/.pre-commit-config-optional.yaml
+++ b/sources/.pre-commit-config-optional.yaml
@@ -5,6 +5,8 @@
 # https://pre-commit.ci/#configuration
 ci:
   autofix_commit_msg: "style(pre-commit-optional): autofix"
+  autoupdate_schedule: quarterly
+  autoupdate_commit_msg: "ci(pre-commit-optional): quarterly autoupdate"
 
 repos:
   - repo: https://github.com/tcort/markdown-link-check

--- a/sources/.pre-commit-config.yaml
+++ b/sources/.pre-commit-config.yaml
@@ -5,6 +5,8 @@
 # https://pre-commit.ci/#configuration
 ci:
   autofix_commit_msg: "style(pre-commit): autofix"
+  autoupdate_schedule: quarterly
+  autoupdate_commit_msg: "ci(pre-commit-optional): quarterly autoupdate"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
## Description

- https://github.com/autowarefoundation/sync-file-templates/pull/57 removed this quarterly schedule.

While I agree with other things in that PR, this frequency should be kept low to reduce maintenance burden.

If not, the pre-commit will create very often auto-update commits regardless of our own workflows.

Check: https://pre-commit.ci/ 

> **automatic updates:** pre-commit.ci will periodically [autoupdate](https://pre-commit.com/#pre-commit-autoupdate) your configuration ensuring that your hook versions are kept up to date. this autoupdate is currently scheduled weekly at approximately 16:00 UTC Monday.

## How was this PR tested?

- Partially reverts https://github.com/autowarefoundation/sync-file-templates/pull/57/files#diff-0f8e64e72e29ef548fe2820a0a5cfdc8b8e2993283708661ddb99d321ea4b6db

This is already the case in autoware universe: https://github.com/autowarefoundation/autoware_universe/pull/11854/files

## Notes for reviewers

None.

## Effects on system behavior

None.
