### PR TITLE
feat: move pre-commit-ansible from autoware repository

### DIFF
--- a/.github/workflows/pre-commit-ansible-autoupdate.yaml
+++ b/.github/workflows/pre-commit-ansible-autoupdate.yaml
@@ -1,0 +1,41 @@
+name: pre-commit-ansible-autoupdate
+
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-secret:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/check-secret.yaml@v1
+    secrets:
+      secret: ${{ secrets.APP_ID }}
+
+  pre-commit-ansible-autoupdate:
+    needs: check-secret
+    if: ${{ needs.check-secret.outputs.set == 'true' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Run pre-commit-autoupdate
+        uses: autowarefoundation/autoware-github-actions/pre-commit-autoupdate@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          pre-commit-config: .pre-commit-config-ansible.yaml
+          pr-labels: |
+            tag:bot
+            tag:pre-commit-autoupdate
+          pr-branch: pre-commit-ansible-autoupdate
+          pr-title: "ci(pre-commit-ansible): autoupdate"
+          pr-commit-message: "ci(pre-commit-ansible): autoupdate"
+          auto-merge-method: squash

--- a/sources/.github/workflows/pre-commit-ansible.yaml
+++ b/sources/.github/workflows/pre-commit-ansible.yaml
@@ -1,0 +1,29 @@
+name: pre-commit-ansible
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit-ansible:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set git config
+        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Ansible Galaxy depends for ansible-lint
+        run: |
+          ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
+
+      - name: Run pre-commit
+        uses: autowarefoundation/autoware-github-actions/pre-commit@v1
+        with:
+          pre-commit-config: .pre-commit-config-ansible.yaml

--- a/sources/.github/workflows/pre-commit-ansible.yaml
+++ b/sources/.github/workflows/pre-commit-ansible.yaml
@@ -1,3 +1,7 @@
+# This file is automatically synced from:
+# https://github.com/autowarefoundation/sync-file-templates
+# To make changes, update the source repository and follow the guidelines in its README.
+
 name: pre-commit-ansible
 
 on:

--- a/sources/.pre-commit-config-ansible.yaml
+++ b/sources/.pre-commit-config-ansible.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/ansible/ansible-lint.git
+    rev: v25.8.2
+    hooks:
+      - id: ansible-lint
+        additional_dependencies:
+          - ansible

--- a/sources/.pre-commit-config-ansible.yaml
+++ b/sources/.pre-commit-config-ansible.yaml
@@ -1,3 +1,7 @@
+# This file is automatically synced from:
+# https://github.com/autowarefoundation/sync-file-templates
+# To make changes, update the source repository and follow the guidelines in its README.
+
 repos:
   - repo: https://github.com/ansible/ansible-lint.git
     rev: v25.8.2


### PR DESCRIPTION
## Description

Import `.github/workflows/pre-commit-ansible.yaml`, `.pre-commit-config-ansible.yaml` as templates, and config updater as workflow from https://github.com/autowarefoundation/autoware .

## How was this PR tested?

None. This is a direct copy-paste from autoware repository.

## Notes for reviewers

None.

## Effects on system behavior

None.
