### PR TITLE
[WIP] chore: bump pre-commit-hooks-ros v0.10.1

### DIFF
--- a/sources/.pre-commit-config.yaml
+++ b/sources/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
       - id: check-package-depends
 
   - repo: https://github.com/tier4/pre-commit-hooks-ros
-    rev: v0.10.0
+    rev: v0.10.1
     hooks:
       - id: flake8-ros
       - id: prettier-xacro


### PR DESCRIPTION
## Description

In tier4 fork of universe, pre-commit-lite was not running properly because it lacked setuptools.

After merging https://github.com/tier4/pre-commit-hooks-ros/pull/107 , I am considering to release a new pre-commit-hook v0.10.1, and then we can bump the version.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
