### PR TITLE
chore: require label only for deploy-docs

### DIFF
--- a/sources/.github/workflows/deploy-docs.yaml
+++ b/sources/.github/workflows/deploy-docs.yaml
@@ -28,6 +28,7 @@ concurrency:
 
 jobs:
   make-sure-label-is-present:
+    if: ${{ github.event_name == 'pull_request_target' }}
     uses: autowarefoundation/autoware-github-actions/.github/workflows/make-sure-label-is-present.yaml@v1
     with:
       label: run:deploy-docs


### PR DESCRIPTION
## Description

Only require tags for deploy-docs workflows in PRs, not push or maunal run.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
