### PR TITLE
chore: update deploy-docs.yaml to trigger only on main push

### DIFF
--- a/sources/.github/workflows/deploy-docs.yaml
+++ b/sources/.github/workflows/deploy-docs.yaml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - galactic
     paths:
       - mkdocs.yaml
       - "**/*.md"


### PR DESCRIPTION
## Description

Remove 'galactic' branch from deployment triggers.

I was unaware that sync-file would sync galactic as well.

<img width="2390" height="800" alt="image" src="https://github.com/user-attachments/assets/ba95a388-a300-4507-b1a7-1c6028560249" />

( https://github.com/autowarefoundation/autoware_universe/pull/12038 )

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
