### PR TITLE
fix: provide correct path for .pre-commit-config-ansible.yaml in autoupdate, and make autoupdate quaterly

### DIFF
--- a/.github/workflows/pre-commit-ansible-autoupdate.yaml
+++ b/.github/workflows/pre-commit-ansible-autoupdate.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/pre-commit-autoupdate@v1
         with:
           token: ${{ steps.generate-token.outputs.token }}
-          pre-commit-config: .pre-commit-config-ansible.yaml
+          pre-commit-config: sources/.pre-commit-config-ansible.yaml
           pr-labels: |
             tag:bot
             tag:pre-commit-autoupdate

--- a/.github/workflows/pre-commit-ansible-autoupdate.yaml
+++ b/.github/workflows/pre-commit-ansible-autoupdate.yaml
@@ -2,7 +2,7 @@ name: pre-commit-ansible-autoupdate
 
 on:
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 1 1,4,7,10 * # quarterly
   workflow_dispatch:
 
 concurrency:

--- a/sources/.pre-commit-config-ansible.yaml
+++ b/sources/.pre-commit-config-ansible.yaml
@@ -9,7 +9,7 @@ ci:
 
 repos:
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v25.8.2
+    rev: v26.1.1
     hooks:
       - id: ansible-lint
         additional_dependencies:

--- a/sources/.pre-commit-config-ansible.yaml
+++ b/sources/.pre-commit-config-ansible.yaml
@@ -2,6 +2,11 @@
 # https://github.com/autowarefoundation/sync-file-templates
 # To make changes, update the source repository and follow the guidelines in its README.
 
+ci:
+  autofix_commit_msg: "style(pre-commit-ansible): autofix"
+  autoupdate_schedule: quarterly
+  autoupdate_commit_msg: "ci(pre-commit-ansible): quarterly autoupdate"
+
 repos:
   - repo: https://github.com/ansible/ansible-lint.git
     rev: v25.8.2

--- a/sources/.pre-commit-config-ansible.yaml
+++ b/sources/.pre-commit-config-ansible.yaml
@@ -2,11 +2,6 @@
 # https://github.com/autowarefoundation/sync-file-templates
 # To make changes, update the source repository and follow the guidelines in its README.
 
-ci:
-  autofix_commit_msg: "style(pre-commit-ansible): autofix"
-  autoupdate_schedule: quarterly
-  autoupdate_commit_msg: "ci(pre-commit-ansible): quarterly autoupdate"
-
 repos:
   - repo: https://github.com/ansible/ansible-lint.git
     rev: v26.1.1


### PR DESCRIPTION
## Description

1. https://github.com/autowarefoundation/sync-file-templates/actions/workflows/pre-commit-ansible-autoupdate.yaml fails because it finds `.pre-commit-config-ansible.yaml` (as from directly pasted from autoware repo), while the config file to update is `sources/.pre-commit-config-ansible.yaml`.

2. make autoupdate quaterly for pre-commit-ansible.

## How was this PR tested?

Provide correct path: https://github.com/autowarefoundation/sync-file-templates/actions/runs/22046816805 (#65 generated)

quaterly autoupdate: None. I just copy-pasted cron from other autoupdates.

## Notes for reviewers

None.

## Effects on system behavior

None.
