### PR TITLE
fix: update pre-commit-ansible workflow and config

### DIFF
--- a/sources/.github/workflows/pre-commit-ansible.yaml
+++ b/sources/.github/workflows/pre-commit-ansible.yaml
@@ -13,10 +13,15 @@ concurrency:
 
 jobs:
   pre-commit-ansible:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
 
       - name: Set git config
         uses: autowarefoundation/autoware-github-actions/set-git-config@v1

--- a/sources/.pre-commit-config-ansible.yaml
+++ b/sources/.pre-commit-config-ansible.yaml
@@ -4,8 +4,10 @@
 
 repos:
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v26.1.1
+    rev: v26.4.0
     hooks:
       - id: ansible-lint
+        args:
+          - ansible/
         additional_dependencies:
           - ansible


### PR DESCRIPTION
## Summary
- Update runner from ubuntu-22.04 to ubuntu-latest
- Update actions/checkout from v4 to v6
- Add setup-python step with Python 3.14
- Update ansible-lint from v26.1.1 to v26.4.0
- Add args for ansible/ directory

## Reference
Syncing from autoware main:
- https://github.com/autowarefoundation/autoware/blob/main/.github/workflows/pre-commit-ansible.yaml
- https://github.com/autowarefoundation/autoware/blob/main/.pre-commit-config-ansible.yaml
- Eliminates https://github.com/autowarefoundation/autoware/pull/6981