### PR TITLE
feat(pre-commit): add autoware_system_designer lint hook

### DIFF
--- a/sources/.pre-commit-config.yaml
+++ b/sources/.pre-commit-config.yaml
@@ -108,6 +108,12 @@ repos:
         files: .svg$
         additional_dependencies: [prettier@2.7.1, "@prettier/plugin-xml@2.2.0"]
 
+  - repo: https://github.com/autowarefoundation/autoware_system_designer
+    rev: v0.3.0
+    hooks:
+      - id: lint-system-design-format
+        args: [--format=github-actions]
+
   - repo: https://github.com/AleksaC/hadolint-py
     rev: v2.14.0
     hooks:

--- a/sources/.pre-commit-config.yaml
+++ b/sources/.pre-commit-config.yaml
@@ -109,7 +109,7 @@ repos:
         additional_dependencies: [prettier@2.7.1, "@prettier/plugin-xml@2.2.0"]
 
   - repo: https://github.com/autowarefoundation/autoware_system_designer
-    rev: v0.3.0
+    rev: v0.3.1
     hooks:
       - id: lint-system-design-format
         args: [--format=github-actions]


### PR DESCRIPTION
## Summary

- Add `lint-system-design-format` pre-commit hook from [`autoware_system_designer`](https://github.com/autowarefoundation/autoware_system_designer) v0.3.0
- Mirrors the change from https://github.com/autowarefoundation/autoware_universe/pull/12153
- Related comment: https://github.com/autowarefoundation/autoware_universe/pull/12261#issuecomment-4163468995