### PR TITLE
ci(dependabot): add config for this repo's own actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval
+    schedule:
+      interval: monthly
+    labels:
+      - tag:bot
+      - type:github-actions
+  - package-ecosystem: github-actions
+    directory: /sources/.github/workflows
+    schedule:
+      interval: monthly
+    labels:
+      - tag:bot
+      - type:github-actions


### PR DESCRIPTION
- Adds `.github/dependabot.yaml` so this repository's own GitHub Actions workflows get monthly version updates.
- Two `updates:` entries: one for the repo's root workflows (`.github/workflows/`) and one for the synced template workflows under `sources/.github/workflows/` so the templates themselves don't drift behind upstream action versions.
- Mirrors the [synced template](https://github.com/autowarefoundation/sync-file-templates/blob/d50a80c6a0194cd539b1b6c1cee51dee12f70bed/sources/.github/dependabot.yaml) (monthly schedule, same labels) but drops `open-pull-requests-limit` since this is the source repo and we want all updates surfaced.

## Why
The template repo distributes a dependabot config to downstream consumers but didn't have one of its own. Without it, neither this repo's workflows nor the source-of-truth templates under `sources/.github/workflows/` ever get action version bumps automatically.

Note: the `type:github-actions` label was created on the repo as part of this change (it didn't exist).