### PR TITLE
ci(codeowners): add repository codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @xmfcx @mitsudome-r @paulsohn


### PR DESCRIPTION
Adds `.github/CODEOWNERS` so every change in this repository requests review from @xmfcx, @mitsudome-r, and @paulsohn by default.

## Why
The repo had no CODEOWNERS, so PRs didn't auto-assign reviewers. This sets a single catch-all rule for the whole tree.