### PR TITLE
ci(workflows): bump runners ubuntu-22.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/comment-on-pr.yaml
+++ b/.github/workflows/comment-on-pr.yaml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   comment-on-pr:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/pre-commit-ansible-autoupdate.yaml
+++ b/.github/workflows/pre-commit-ansible-autoupdate.yaml
@@ -18,7 +18,7 @@ jobs:
   pre-commit-ansible-autoupdate:
     needs: check-secret
     if: ${{ needs.check-secret.outputs.set == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/pre-commit-autoupdate.yaml
+++ b/.github/workflows/pre-commit-autoupdate.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pre-commit-autoupdate:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/pre-commit-optional-autoupdate.yaml
+++ b/.github/workflows/pre-commit-optional-autoupdate.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pre-commit-optional-autoupdate:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/sources/.github/workflows/backport.yaml
+++ b/sources/.github/workflows/backport.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # Only react to merged PRs for security reasons.
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
     if: >

--- a/sources/.github/workflows/build-and-test-differential.yaml
+++ b/sources/.github/workflows/build-and-test-differential.yaml
@@ -25,7 +25,7 @@ jobs:
   build-and-test-differential:
     needs: require-label
     if: ${{ needs.require-label.outputs.result == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ${{ matrix.container }}
     strategy:
       fail-fast: false

--- a/sources/.github/workflows/build-and-test.yaml
+++ b/sources/.github/workflows/build-and-test.yaml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build-and-test:
     if: ${{ github.event_name != 'push' || github.ref_name == github.event.repository.default_branch }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ${{ matrix.container }}
     strategy:
       fail-fast: false

--- a/sources/.github/workflows/cancel-previous-workflows.yaml
+++ b/sources/.github/workflows/cancel-previous-workflows.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   cancel-previous-workflows:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.13.1

--- a/sources/.github/workflows/check-build-depends.yaml
+++ b/sources/.github/workflows/check-build-depends.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   check-build-depends:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ${{ matrix.container }}
     strategy:
       fail-fast: false

--- a/sources/.github/workflows/clang-tidy-pr-comments-manually.yaml
+++ b/sources/.github/workflows/clang-tidy-pr-comments-manually.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   clang-tidy-pr-comments-manually:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/sources/.github/workflows/clang-tidy-pr-comments.yaml
+++ b/sources/.github/workflows/clang-tidy-pr-comments.yaml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   clang-tidy-pr-comments:
     if: ${{ github.event.workflow_run.event == 'pull_request' && contains(fromJson('["success", "failure"]'), github.event.workflow_run.conclusion) }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/sources/.github/workflows/comment-on-pr.yaml
+++ b/sources/.github/workflows/comment-on-pr.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   comment-on-pr:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
     steps:

--- a/sources/.github/workflows/delete-closed-pr-docs.yaml
+++ b/sources/.github/workflows/delete-closed-pr-docs.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   delete-closed-pr-docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/sources/.github/workflows/deploy-docs.yaml
+++ b/sources/.github/workflows/deploy-docs.yaml
@@ -34,7 +34,7 @@ jobs:
   deploy-docs:
     needs: make-sure-label-is-present
     if: ${{ github.event_name != 'pull_request_target' || needs.make-sure-label-is-present.outputs.result == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/sources/.github/workflows/github-release.yaml
+++ b/sources/.github/workflows/github-release.yaml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   github-release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Set tag name
         id: set-tag-name

--- a/sources/.github/workflows/pr-agent.yaml
+++ b/sources/.github/workflows/pr-agent.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   pr_agent_job:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
       pull-requests: write

--- a/sources/.github/workflows/pre-commit-ansible.yaml
+++ b/sources/.github/workflows/pre-commit-ansible.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   pre-commit-ansible:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/sources/.github/workflows/pre-commit-autoupdate.yaml
+++ b/sources/.github/workflows/pre-commit-autoupdate.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   pre-commit-autoupdate:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/sources/.github/workflows/pre-commit-optional-autoupdate.yaml
+++ b/sources/.github/workflows/pre-commit-optional-autoupdate.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   pre-commit-optional-autoupdate:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/sources/.github/workflows/pre-commit-optional.yaml
+++ b/sources/.github/workflows/pre-commit-optional.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   pre-commit-optional:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/sources/.github/workflows/pre-commit.yaml
+++ b/sources/.github/workflows/pre-commit.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   pre-commit:
     if: ${{ github.event.repository.private }} # Use pre-commit.ci for public repositories
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/sources/.github/workflows/spell-check-daily.yaml
+++ b/sources/.github/workflows/spell-check-daily.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   spell-check-daily:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/sources/.github/workflows/spell-check-differential.yaml
+++ b/sources/.github/workflows/spell-check-differential.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   spell-check-differential:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/sources/.github/workflows/sync-branches.yaml
+++ b/sources/.github/workflows/sync-branches.yaml
@@ -35,7 +35,7 @@ concurrency:
 
 jobs:
   sync-branches:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Validate inputs and compute PR branch name
         id: prepare

--- a/sources/.github/workflows/sync-files.yaml
+++ b/sources/.github/workflows/sync-files.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   sync-files:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/sources/.github/workflows/update-codeowners-from-packages.yaml
+++ b/sources/.github/workflows/update-codeowners-from-packages.yaml
@@ -22,7 +22,7 @@ jobs:
   update-codeowners-from-packages:
     needs: check-secret
     if: ${{ needs.check-secret.outputs.set == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token


### PR DESCRIPTION
- Bumps `runs-on: ubuntu-22.04` → `runs-on: ubuntu-24.04` across 25 workflows: 4 in this repo's own `.github/workflows/` and 21 in the synced templates under `sources/.github/workflows/`.
- Pins `sources/.github/workflows/pre-commit-ansible.yaml` from `ubuntu-latest` to `ubuntu-24.04` so every runner in this repo is explicit and consistent.

## Why
GitHub is winding down the `ubuntu-22.04` runner image. Moving both this repo's CI and the templates synced to downstream Autoware consumers off it now avoids surprise breakage when the image is retired.

Build workflows (`build-and-test*`, `check-build-depends`, `clang-tidy-pr-comments*`) use `ros:humble` / `ros:jazzy` container blocks, so the ROS distro's Ubuntu target lives inside the container — the host runner bump is decoupled from the in-container build environment.

After this PR there are no remaining `ubuntu-22.04` or `ubuntu-latest` references anywhere in the repo.