### PR TITLE
feat(pre-commit): add format-cspell-json hook from autoware-spell-check-dict

### DIFF
--- a/sources/.pre-commit-config.yaml
+++ b/sources/.pre-commit-config.yaml
@@ -114,6 +114,11 @@ repos:
       - id: lint-system-design-format
         args: [--format=github-actions]
 
+  - repo: https://github.com/autowarefoundation/autoware-spell-check-dict
+    rev: e9d756af3ac14bacd5c9cea188d47b39d3160f53
+    hooks:
+      - id: format-cspell-json
+
   - repo: https://github.com/AleksaC/hadolint-py
     rev: v2.14.0
     hooks:

--- a/sources/.prettierignore
+++ b/sources/.prettierignore
@@ -4,3 +4,4 @@
 
 *.param.yaml
 *.rviz
+.cspell.json


### PR DESCRIPTION
## Description

- Add `format-cspell-json` pre-commit hook from [autoware-spell-check-dict](https://github.com/autowarefoundation/autoware-spell-check-dict)
- Automatically sort and format `.cspell.json` in synced repositories
- edit .prettierignore to fixing conflict

## How was this PR tested?
I confirmed in my https://github.com/h-ohta/autoware-github-actions/pull/103

## Notes for reviewers

None.

## Effects on system behavior

None.
